### PR TITLE
Expose more highlighting methods

### DIFF
--- a/CoreDragon/DragonController.h
+++ b/CoreDragon/DragonController.h
@@ -47,6 +47,13 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Misc
 /*!	Is the user currently dragging something, in this app or any other app? */
 - (BOOL)draggingOperationIsInProgress;
+
+/*! Recalculates active drop targets, e.g. to allow for refreshing cells in scrolling table view. */
+- (void)recalculateActiveDropTargets;
+
+/*! Explicitely invalidates and redraws a highlight for a specific view. */
+- (void)invalidateHighlightForView:(UIView *)view;
+
 @end
 
 /// Information about a dragging operation that is about to start or is in progress.


### PR DESCRIPTION
This diff allows the user to request a recalculation of drop targets in case the available drop targets on the screen change during the drag. (e.g. when a table view is scrolling)

It also exposes the ability to redraw a highlight associated with the view managed by Core Dragon.

cc @nevyn 
